### PR TITLE
Fixed superagent incompatibility

### DIFF
--- a/lib/auth-protected.js
+++ b/lib/auth-protected.js
@@ -21,7 +21,7 @@ function getPublicKeys(issuer) {
   } else {
     return request
       .get(issuer.public_keys_url)
-      .then(function(response) { return response.json() })
+      .then(function(response) { return response.body })
   }
 }
 


### PR DESCRIPTION
superagent has no method `.json()` on the response object,
if the content type is json the field `.body` will be
populated with the parsed content.